### PR TITLE
 CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-lusid-sdk-preview
+lusid-sdk-preview < 2


### PR DESCRIPTION

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions 1.0.x however that is not true, so now pinning < 2